### PR TITLE
fix segment width bug when the height were given

### DIFF
--- a/src/panel.jl
+++ b/src/panel.jl
@@ -147,7 +147,7 @@ function Panel(
     # add empty lines to ensure target height is reached
     if !isnothing(height) && content_measure.h < height
         for i = 1:(height-content_measure.h)
-            line = " "^(width)
+            line = " "^(width - 2)
             push!(segments, Segment(left * line * right))
         end
     end


### PR DESCRIPTION
```julia
p = Panel(""; width = 5, height = 4)
julia> println(p)
```
*Before* 
![image](https://user-images.githubusercontent.com/7087745/157199977-d1b01bbc-7c7a-4f13-bcdc-253cd4318940.png)

*After*
![image](https://user-images.githubusercontent.com/7087745/157200120-21d1be28-8c31-4b96-b65f-035a6ed98edc.png)