### PR TITLE
Add documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Related:
 - https://github.com/KristofferC/Crayons.jl
 - https://github.com/Aerlinger/AnsiColor.jl
 
-
+[![Dev docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://fedeclaudi.github.io/Term.jl/dev/)
 
 ## Roadmap
 


### PR DESCRIPTION
Very excited about this package! Just took me a little digging to find the documentation, which is excellent! At least the parts that are finished :sweat_smile: 

This just adds a docs badge to the README.md. If you hadn't done that because they're unfinished, I wouldn't worry about it. Just reading what you have got me interested in trying things out! 