### PR TITLE
Use vline instead of leaf for deeper levels of guide

### DIFF
--- a/src/tree.jl
+++ b/src/tree.jl
@@ -222,7 +222,7 @@ function render(tree::Tree; prevguides::String="", lasttree=false, waslast=[], g
 
             else
                 _end = n == length(waslast) ? guides.branch : guides.vline
-                _pre_guides *= lasttree ? guides.leaf : _end
+                _pre_guides *= lasttree ? (l ? guides.leaf : guides.vline) : _end
             end
         end
 


### PR DESCRIPTION
Reproducer:
```
using Term.tree: Tree
d1 = Dict(1 => 2, 3 => 4)
d2 = Dict(1 => d1, 2 => d1)
d3 = Dict(1 => d2, 2 => d2)
print(Tree(d3))
```

Without PR:
```
 tree             
━━━━━━            
  │               
  ├── 2           
  │   ├── 2       
  │   │   ├── 3: 4
  │   │   └── 1: 2
  └── └── 1       
  │       ├── 3: 4
  │       └── 1: 2
  └── 1           
      ├── 2       
      │   ├── 3: 4
      │   └── 1: 2
      └── 1       
          ├── 3: 4
          └── 1: 2
```

With PR:
```
 tree             
━━━━━━            
  │               
  ├── 2           
  │   ├── 2       
  │   │   ├── 3: 4
  │   │   └── 1: 2
  │   └── 1       
  │       ├── 3: 4
  │       └── 1: 2
  └── 1           
      ├── 2       
      │   ├── 3: 4
      │   └── 1: 2
      └── 1       
          ├── 3: 4
          └── 1: 2
```
