### PR TITLE
Add `foreachprogress`

### DIFF
--- a/src/progress.jl
+++ b/src/progress.jl
@@ -28,7 +28,15 @@ import ..Colors: RGBColor
 import ..Layout: hLine
 
 export ProgressBar,
-    ProgressJob, addjob!, start!, stop!, update!, removejob!, with, @track, render,
+    ProgressJob,
+    addjob!,
+    start!,
+    stop!,
+    update!,
+    removejob!,
+    with,
+    @track,
+    render,
     foreachprogress
 
 # ---------------------------------------------------------------------------- #
@@ -614,7 +622,7 @@ macro track(ex)
 end
 
 
-const FOREACH_PROGRESS = ProgressBar(transient=true)
+const FOREACH_PROGRESS = ProgressBar(transient = true)
 
 """
     foreachprogress(f, iter[, pbar; parallel=false, transient=true, description])
@@ -671,8 +679,15 @@ foreachprogress(1:50; description = "Working...", parallel=true) do i
 end
 ```
 """
-function foreachprogress(f, iter, pbar = FOREACH_PROGRESS; n = _getn(iter), transient = true,
-                         parallel = false, kwargs...)
+function foreachprogress(
+    f,
+    iter,
+    pbar = FOREACH_PROGRESS;
+    n = _getn(iter),
+    transient = true,
+    parallel = false,
+    kwargs...,
+)
     task = nothing
     try
         # Only handle rendering of progress bar if it is not already running.
@@ -708,7 +723,7 @@ function foreachprogress(f, iter, pbar = FOREACH_PROGRESS; n = _getn(iter), tran
 end
 
 _getn(iter) = _getn(iter, Base.IteratorSize(iter))
-_getn(iter, ::Union{Base.HasLength, <:Base.HasShape}) = length(iter)
+_getn(iter, ::Union{Base.HasLength,<:Base.HasShape}) = length(iter)
 _getn(_, _) = nothing
 
 

--- a/test/15_test_progress.jl
+++ b/test/15_test_progress.jl
@@ -91,6 +91,13 @@ end
     @test job.columns[1].segments[1].text == "\e[31mRunning...\e[39m"
 end
 
+@testset "\e[34mProgress foreachprogress" begin
+    @test_nowarn redirect_stdout(Base.DevNull()) do
+        Term.Progress.foreachprogress(1:10) do i
+            sleep(0.01)
+        end
+    end
+end
 # @testset "\e[34mProgress ProgressLogging" begin
 #     install_term_logger()
 


### PR DESCRIPTION
This adds `foreachprogress` which behaves like `Base.foreach`, but prints progress while iterating through the iterator.

Notably, it supports nesting calls which allows tracking the progress of hierarchical tasks. It also supports threading using the `Threads.@threads` macro.



See the example:


```julia
pbar = Term.ProgressBar()
foreachprogress(1:100, pbar,   description = "Outer    ", parallel=true) do i
    foreachprogress(1:5, pbar, description = "    Inner") do j
        sleep(rand() / 5)
    end
end
```

https://user-images.githubusercontent.com/28812146/174477904-93b729c3-24ac-4525-a94b-ff37cda759ef.mov


