### PR TITLE
Allow disabling panel trimming on large plots

### DIFF
--- a/src/_errors.jl
+++ b/src/_errors.jl
@@ -7,12 +7,6 @@ function render_frame_info(pointer::Ptr{Nothing}; show_source = true)
     return RenderableText("   " * string(frame); width = default_stacktrace_width() - 12)
 end
 
-function render_frame_info(pointer::Ptr{Nothing}; show_source = true)
-    frame = StackTraces.lookup(pointer)[1]
-    return render_frame_info(frame; show_source = show_source)
-    return RenderableText("   " * string(frame); width = DEFAULT_WIDTH[])
-end
-
 function render_frame_info(frame::StackFrame; show_source = true)
     func = sprint(StackTraces.show_spec_linfo, frame)
     func = replace(

--- a/src/panels.jl
+++ b/src/panels.jl
@@ -148,13 +148,14 @@ end
         padding::Padding;
         height::Union{Nothing,Int} = nothing,
         width::Union{Nothing,Int} = nothing,
+        trim::Bool = true,
         kwargs...,
-        )
+    )
 
 Construct a `Panel` fitting the content's width.
 
 !!! warning
-    If the content is larger than the console terminal's width, it will get trimmed to avoid overflow.
+    If the content is larger than the console terminal's width, it will get trimmed to avoid overflow, unless `trim=false` is given.
 """
 function Panel(
     content::Union{AbstractString,AbstractRenderable},
@@ -163,6 +164,7 @@ function Panel(
     height::Union{Nothing,Int} = nothing,
     width::Union{Nothing,Int} = nothing,
     background::Union{Nothing,String} = nothing,
+    trim::Bool = true,
     kwargs...,
 )
     content =
@@ -178,13 +180,15 @@ function Panel(
     )
 
     # if panel is larger than console, fit content to panel
-    panel_measure.w > console_width() && return Panel(
-        content,
-        Val(false),
-        padding;
-        width = min(panel_measure.w, console_width() - 1),
-        kwargs...,
-    )
+    if panel_measure.w > console_width() && trim
+        return Panel(
+            content,
+            Val(false),
+            padding;
+            width = min(panel_measure.w, console_width() - 1),
+            kwargs...,
+        )
+    end
 
     Δw = padding.left + padding.right + 2
     Δh = padding.top + padding.bottom


### PR DESCRIPTION
I sometimes don't want my large plots to get trimmed by `Term` since it messes up with the canvas content and ansi codes.

Maybe there is a better choice for the keyword naming.

Example:
```julia
using UnicodePlots, Term

panel(plt; kw...) = Panel(string(plt, color=true); style="hidden", trim=false, kw...)

plots = [lineplot(1:10, width=100) for _ in 1:4]

grid(panel.(plots)) |> display
```

Also fix a duplicate declaration breaking precompilation introduced by https://github.com/FedeClaudi/Term.jl/pull/115.