### PR TITLE
Re-added poster example in docs.

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,12 @@ CurrentModule = Term
 # Term
 
 `Term.jl` is a Julia library for producing styled, beautiful terminal output, like this:
-    
+
+```@example
+import Term
+print(Term.make_logo())
+```
+
 `Term.jl` uses a simple *markup* syntax to add style information to standard Julia strings.
 It also provides `Renderable` objects such as the `Panel` and `TextBox` as you can see in the example below.
 These too can be styled, include styled text, and they can be nested and stacked to produce


### PR DESCRIPTION
In the documentation in `index.md`, the first example is missing. It seems to have been removed in b4290fffe942623fd8378003298d91ec491e61e9. This commit simply adds it back, assuming it was removed by a mistake.