### PR TITLE
Add a docstring for the Term module/package.

### DIFF
--- a/src/Term.jl
+++ b/src/Term.jl
@@ -1,3 +1,33 @@
+"""
+    Term.jl
+
+Welcome to Term.jl! Term.jl is a Julia library for producing styled, beautiful terminal output.
+
+# Documentation
+
+See https://fedeclaudi.github.io/Term.jl for documentation.
+
+# Demonstration
+
+```julia
+using Term
+const term_demo = joinpath(dirname(pathof(Term)), "..", "README.jl")
+include(term_demo) # view demo
+less(term_demo) # see demo code
+```
+
+# Example
+
+```jldoctest
+begin
+    println(@green "this is green")
+    println(@blue "and this is blue")
+    println()
+    println(@bold "this is bold")
+    println(@underline "and this is underlined")
+end
+```
+"""
 module Term
 
 const DEBUG_ON = Ref(false)


### PR DESCRIPTION
This adds a docstring for the `Term` module. The docstring can be accessed via `?Term` after `using Term`.

```julia
julia> using Term

help?> Term
search: Term termshow TERM_THEME sortperm sortperm! pointer_from_objref

  Term.jl

  Welcome to Term.jl! Term.jl is a Julia library for producing styled, beautiful
  terminal output.

  Documentation
  ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

  See https://fedeclaudi.github.io/Term.jl for documentation.

  Demonstration
  ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

  using Term
  const term_demo = joinpath(dirname(pathof(Term)), "..", "README.jl")
  include(term_demo) # view demo
  less(term_demo) # see demo code

  Example
  ≡≡≡≡≡≡≡≡≡

  begin
      println(@green "this is green")
      println(@blue "and this is blue")
      println()
      println(@bold "this is bold")
      println(@underline "and this is underlined")
  end
```