### PR TITLE
Add docstring to `typestree`

### DIFF
--- a/src/introspection.jl
+++ b/src/introspection.jl
@@ -42,7 +42,41 @@ export inspect, typestree, expressiontree
 # ---------------------------------------------------------------------------- #
 #                                TYPES HIERARCHY                               #
 # ---------------------------------------------------------------------------- #
+"""
+    typestree(T)
+    typestree(io::IO, T)
 
+Print the type hierarchy for `T` in a pretty format. This is 
+done using colors, indentation and unicode for maximal readability.
+The output included all supertypes, and one level of subtypes.
+
+This function is not exported, so to use it you need to 
+use the `Term.typestree` syntax, or import it manually by
+`import Term: typestree`
+
+# Example
+Below is an example showing the type tree for `Integer`. Note 
+that the colors of the output are not included in this docstring.
+```jldoctest
+julia> Term.typestree(Integer)
+╭────────────── Types hierarchy ───╮
+│                                  │
+│  Number                          │
+│ ━━━━━━━━                         │
+│    │                             │
+│    ├── Complex                   │
+│    └── Real                      │
+│        ├── Rational              │
+│        ├── AbstractIrrational    │
+│        ├── Integer               │
+│        │   ├── Signed            │
+│        │   ├── Unsigned          │
+│        │   └── Bool              │
+│        └── AbstractFloat         │
+│                                  │
+╰──────────────────────────────────╯
+```
+"""
 typestree(io::IO, T::DataType) = print(
     io,
     Panel(


### PR DESCRIPTION
Added a docstring to `typestree`, because I could not find the function when I went looking for it, despite knowing that it existed. 

The only reference I could find is https://github.com/JuliaLang/julia/issues/24741, which I read some time ago, and is the only reason I know that it existed.

This PR should make it so that when you search for "supertype", "subtypes", or "tree", the function should appear in the documentation, which was the original problem.