### PR TITLE
Remove 1.0 warning

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,10 +9,6 @@ It also provides `Renderable` objects such as the `Panel` and `TextBox` as you c
 These too can be styled, include styled text, and they can be nested and stacked to produce
 structured visual displays in your terminal. 
 
-
-!!! warning "Version 1.0"
-    If you're an early adopter of Term, I have some bad news for you (and some good). Version `1.0` introduces some breaking changes. I know, I know. But it's worth it, I promise, and it has a ton of new features and improvements. The main thing you need to look out for is the markup syntax. Instead of `[...] content [/...]` now you need to use `{...} content {/...}`. That's right, curly braces instead of square. It's not a huge change!
-
 !!! warning "OS concerns"
     `Term` has been tested extensively so far, but only on Mac. If you're using a Linux or Windows machine you might find some bugs that have eluded us so far. Please get in touch so that we can fix them!
 


### PR DESCRIPTION
With 2.0 out, it seemed appropriate to remove a warning about breaking changes made in 1.0, especially since it was so prominent. I may be wrong on that, I have no idea what the timelines are and what amount of grief you get from users about the changes informed about in the warning.