### PR TITLE
Fix the toggle button constructor

### DIFF
--- a/src/Live/buttons.jl
+++ b/src/Live/buttons.jl
@@ -155,7 +155,7 @@ function ToggleButton(
     on_deactivated::Function = on_deactivated,
     kwargs...,
 )
-    return Button(
+    return ToggleButton(
         WidgetInternals(Measure(), nothing, on_draw, on_activated, on_deactivated, false),
         controls,
         message,


### PR DESCRIPTION
The constructor for the `ToggleButton` returns a standard `Button` and so no toggling functionality is present. This PR fixes this.