### PR TITLE
Fix `foreachprogress` returning early

### DIFF
--- a/src/progress.jl
+++ b/src/progress.jl
@@ -688,7 +688,6 @@ function foreachprogress(
             start!(pbar)
             task = Threads.@spawn _startrenderloop(pbar)
         end
-        return
 
         # The job tracks the iteration through `iter`
         job = addjob!(


### PR DESCRIPTION
In the current version, `foreachprogress` exits without doing or showing a thing. 
It looks like a stray `return` is the culprit? 
This PR deletes it 🕺

As a simple example:
```julia
x = zeros(10)
foreachprogress(eachindex(x); description = "Working...") do i
    @info i
    x[i] = 1
    sleep(0.1)
end
sum(x)
```

Current behavior: prints nothing, returns `0`
New behavior: prints `@info` and `ProgressBar`, returns `10`



