### PR TITLE
Add a feature to the progress bar that displays additional variables …

### DIFF
--- a/test/15_test_progress.jl
+++ b/test/15_test_progress.jl
@@ -15,19 +15,19 @@ using ProgressLogging
 
     j1 = addjob!(pbar; description = "test", N = 10)
     @test render(j1) isa String  # coverage
-    @test jobcolor(j1) == "(190, 35, 112)"
+    @test jobcolor(j1) == "(209, 16, 112)"
 
     @test j1.id == 1
     @test j1.N == 10
-    @test j1.i == 1
+    @test j1.i == 0
     @test j1.description == "test"
     @test j1.started
     @test j1.columns isa Vector{AbstractColumn}
 
     update!(j1)
-    @test j1.i == 2
+    @test j1.i == 1
     update!(j1; i = 10)
-    @test j1.i == 12
+    @test j1.i == 11
 
     @test getjob(pbar, j1.id).id == j1.id
 


### PR DESCRIPTION
…and their values.

```julia
using Term.Progress
a = 10
b = 0.1
extra_info = Dict("Current loss" => a, "Learning rate" => b)
pbar = ProgressBar(; extra_info)
job = addjob!(pbar; N = 5)
start!(pbar)
for i in 1:5
    a = 10-i
    b = 0.1i
    println("Epoch $i")
    pbar.extra_info = Dict("Current loss" => a, "Learning rate" => b)
    update!(job)
    render(pbar)
    sleep(1)
end
stop!(pbar)
```

And the output will be:
```
Epoch 1
Epoch 2 ...
─────────────────────────── progress ───────────────────────────
Running... ● ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ● 5/5 100%
Current loss  : 5
Learning rate : 0.5
```
	modified:   src/progress.jl