### PR TITLE
	modified:   src/progress.jl

### DIFF
--- a/src/progress.jl
+++ b/src/progress.jl
@@ -270,7 +270,7 @@ mutable struct ProgressBar
     paused::Bool
     task::Union{Task,Nothing}
     renderstatus::Any
-    extra_info::Union{Dict{String,<:Any},Nothing}
+    extra_info::Dict{String,<:Any}
 end
 
 """
@@ -286,7 +286,7 @@ end
             RGBColor("(.05, 1, .05)"),
         ],
         refresh_rate::Int = 60,  # FPS of rendering
-        extra_info::Union{Dict{String,<:Any},Nothing} = nothing,
+        extra_info::Dict{String,<:Any} = Dict{String,Any}(),
     )
 
 Create a ProgressBar instance.
@@ -299,7 +299,7 @@ function ProgressBar(;
     transient::Bool                         = false,
     colors::Union{String,Vector{RGBColor}}  = [RGBColor("(1, .05, .05)"), RGBColor("(.05, .05, 1)"), RGBColor("(.05, 1, .05)")],
     refresh_rate::Int                       = 60,  # FPS of rendering
-    extra_info::Union{Dict{String,<:Any},Nothing} = nothing,
+    extra_info::Dict{String,<:Any}          = Dict{String,Any}(),
 )
     columns = columns isa Symbol ? get_columns(columns) : columns
 
@@ -530,7 +530,7 @@ function render(pbar::ProgressBar)
     end
 
     # render the extra information
-    if !isnothing(pbar.extra_info)
+    if !isempty(pbar.extra_info)
         max_len = maximum(length.(keys(pbar.extra_info)))
         for (k, v) in pbar.extra_info
             write(iob, "\n" * k * " "^(max_len - length(k)) * " : " * string(v))


### PR DESCRIPTION
Fixed an issue where `length(pbar.extra_info)` reported an error when `extra_info = nothing`. Now `extra_info` is initialized to an empty dictionary `Dict{String,Any}()`. Here's another simple example of how to use extra_info:
```julia
using Term.Progress, Dates
a = 10
iteration_time = NaN
extra_info = Dict("Speed" => "$iteration_time s/it", "Start time" => now(), "a" => a)
pbar = ProgressBar(; extra_info)
job = addjob!(pbar; N = 5)
start!(pbar)
for i in 1:5
    iteration_time = @elapsed begin
        a = 10 - i
        println("Epoch $i")
        pbar.extra_info["Speed"] = "$iteration_time s/it"
        update!(job)
        render(pbar)
        sleep(1)
    end
end
stop!(pbar)
```
And the output will be:
```
Epoch 1
Epoch 2...
──────────────────────────── progress ─────────────────────────────     
Running... ● ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ● 5/5 100%     
Start time : 2025-01-08T12:57:06.673
Speed      : 1.0087561 s/it
a          : 5
```