### PR TITLE
Fix live apps

### DIFF
--- a/src/Live/app.jl
+++ b/src/Live/app.jl
@@ -42,7 +42,7 @@ other widgets to access their internal variables.
 
         # prepare terminal 
         raw_mode_enabled = try
-            raw!(terminal, true)
+            raw!(get_terminal(), true)
             true
         catch err
             @debug "Unable to enter raw mode: " exception = (err, catch_backtrace())
@@ -50,11 +50,11 @@ other widgets to access their internal variables.
         end
 
         # hide the cursor
-        raw_mode_enabled && print(terminal.out_stream, "\x1b[?25l")
+        raw_mode_enabled && print(get_terminal().out_stream, "\x1b[?25l")
         return new(
             iob,
             ioc,
-            terminal,
+            get_terminal(),
             nothing,
             String[],
             raw_mode_enabled,

--- a/src/Live/app.jl
+++ b/src/Live/app.jl
@@ -35,7 +35,11 @@ other widgets to access their internal variables.
     help_message::Union{Nothing,String}
     should_stop::Bool
 
-    function AppInternals(; refresh_rate::Int = 60, help_message = nothing)
+    function AppInternals(;
+        refresh_rate::Int = 60,
+        help_message = nothing,
+        suppress_output = false,
+    )
         # get output buffers
         iob = IOBuffer()
         ioc = IOContext(iob, :displaysize => displaysize(stdout))
@@ -45,7 +49,8 @@ other widgets to access their internal variables.
             raw!(get_terminal(), true)
             true
         catch err
-            @debug "Unable to enter raw mode: " exception = (err, catch_backtrace())
+            suppress_output ||
+                @warn "Unable to enter raw mode: " exception = (err, catch_backtrace())
             false
         end
 

--- a/src/Live/keyboard_input.jl
+++ b/src/Live/keyboard_input.jl
@@ -7,9 +7,9 @@ if it exists. Returns a list of return values from the control functions.
 """
 function keyboard_input(widget::AbstractWidget)
     controls = widget.controls
-    if bytesavailable(terminal.in_stream) > 0
+    if bytesavailable(get_terminal().in_stream) > 0
         # get input
-        c = readkey(terminal.in_stream)
+        c = readkey(get_terminal().in_stream)
         c = haskey(KEYs, Int(c)) ? KEYs[Int(c)] : Char(c)
 
         # see if a control has been defined for this key
@@ -28,9 +28,9 @@ Get keyboard input from the terminal and execute the corresponding control funct
 """
 function keyboard_input(widget::AbstractWidgetContainer)
     retvals = []
-    if bytesavailable(terminal.in_stream) > 0
+    if bytesavailable(get_terminal().in_stream) > 0
         # get input
-        c = readkey(terminal.in_stream)
+        c = readkey(get_terminal().in_stream)
         c = haskey(KEYs, Int(c)) ? KEYs[Int(c)] : Char(c) # ::Union{Char, KeyInput}
 
         # execute command on each subwidget

--- a/src/Live/live.jl
+++ b/src/Live/live.jl
@@ -2,10 +2,13 @@ module LiveWidgets
 import REPL
 import REPL.Terminals: raw!, AbstractTerminal
 import REPL.TerminalMenus: readkey
-const terminal = @static if isdefined(REPL.TerminalMenus, :default_terminal)
-    REPL.TerminalMenus.default_terminal()
-else
-    REPL.TerminalMenus.terminal
+
+function get_terminal()
+    return @static if isdefined(REPL.TerminalMenus, :default_terminal)
+        REPL.TerminalMenus.default_terminal()
+    else
+        REPL.TerminalMenus.terminal
+    end
 end
 
 using Dates


### PR DESCRIPTION
For whatever reason, we cannot get into raw mode using the patch in eaf337c. This meant live apps are basically broken.

Looking at JuliaLang/julia@5023ee21d70b734edf206aab3cac7c202ee0235a , all instances of `terminal` were replaced with a getter (in their case, `default_terminal()`). We basically do the same thing here, with a static check to see if `default_terminal()` exists, and if not returns `REPL.TerminalMenus.terminal`.  This is mainly for backwards compatibility, in line eaf337c.

I have no idea why the getter function works and the constant does not, maybe someone can explain this to me.

Also, I've changed from debug to warning level if we cant get into raw mode.

Working locally on Windows & WSL, using julia 1.10.7, 1.11.2, 1.12.0.

This should fix #252 #253