### PR TITLE
Fix TermLogger and ProgressLogging compatibility

### DIFF
--- a/src/logs.jl
+++ b/src/logs.jl
@@ -149,7 +149,7 @@ function handle_progress(logger::TermLogger, prog)
         map(j -> removejob!(pbar, j), pbar.jobs)
         stop!(pbar)
     else
-        render(pbar)
+        render(pbar, logger.io)
     end
 end
 
@@ -324,6 +324,8 @@ function Logging.handle_message(
 
     # generate log
     logged = sprint(print_log_message, logger, lvl, msg, _mod, file, line, kwargs)
+    write(logger.io, logged)
+    flush(logger.io)
 
     # restore stdout
     NOCOLOR[] && (logged = cleantext(logged))

--- a/src/logs.jl
+++ b/src/logs.jl
@@ -1,6 +1,6 @@
 module Logs
 
-using ProgressLogging: asprogress
+using ProgressLogging: asprogress, ProgressLevel
 using InteractiveUtils
 using Dates: Dates
 using Logging
@@ -78,7 +78,7 @@ function TermLogger(io::IO, theme::Theme = TERM_THEME[])
 end
 
 # set logger beavior
-Logging.min_enabled_level(logger::TermLogger) = Logging.Info
+Logging.min_enabled_level(logger::TermLogger) = ProgressLevel
 
 Logging.shouldlog(logger::TermLogger, level, _module, group, id) = true
 Logging.catch_exceptions(logger::TermLogger) = true
@@ -322,7 +322,7 @@ function Logging.handle_message(
     _progress = asprogress(lvl, msg, _mod, group, id, file, line; kwargs...)
     isnothing(_progress) || return handle_progress(logger, _progress)
 
-    # generate log 
+    # generate log
     logged = sprint(print_log_message, logger, lvl, msg, _mod, file, line, kwargs)
 
     # restore stdout

--- a/src/progress.jl
+++ b/src/progress.jl
@@ -465,22 +465,22 @@ function render(job::ProgressJob)::String
 end
 
 """
-    render(job::ProgressJob, pbar::ProgressBar)::String
+    render(pbar::ProgressBar, [io=stdout])::String
 
 Render a `ProgressBar`.
 
 When a progress bar is first rendered, this function uses
 ANSI codes to change the scrolling region of the terminal
 window to create a space at the bottom where the bar's visuals
-can be displayed. This allows for thext printed to `stdout` to
+can be displayed. This allows for text printed to `stdout` to
 still be visualized. On subsequent calls, this function
 ensures that the height of the reserved space matches the
 number of running jobs.
 
-All fo this requires a bit of careful work in moving the
+All of this requires a bit of careful work in moving the
 cursor around and doing ANSI magic.
 """
-function render(pbar::ProgressBar)
+function render(pbar::ProgressBar, io = stdout)
     # check if running
     pbar.running || return nothing
 
@@ -539,7 +539,8 @@ function render(pbar::ProgressBar)
 
     # restore position and write
     move_to_line(iob, pbar.renderstatus.scrollline)
-    return print(String(take!(iob)))
+    write(io, String(take!(iob)))
+    return flush(io)
 end
 
 # ---------------------------------------------------------------------------- #

--- a/src/progress.jl
+++ b/src/progress.jl
@@ -186,7 +186,7 @@ function update!(job::ProgressJob; i = nothing)
     if !isnothing(job.N) && job.i ≥ job.N
         stop!(job)
     else
-        job.i += something(i, 1)
+        job.i = something(i, 1 + job.i)
     end
     return nothing
 end


### PR DESCRIPTION
Previously, the TermLogger progress bar printed nothing because the minimum log level was set to `Info` rather than `ProgressLevel`, and the `update!` method would increment by the value of `i` (rather than setting the value to `i`, as suggested by the docs and code base), causing the progress bar to overflow

To test the TermLogger functionality, I also made sure a custom io could be passed to TermLogger (and therefore ProgressBar)

ProgressLogging integration should now work as described in the docs