### PR TITLE
Draw top border of `Table` box when `show_header=false`

### DIFF
--- a/src/tables.jl
+++ b/src/tables.jl
@@ -214,19 +214,21 @@ function Table(
         )
 
         # prep row params based on line number, header etc...
-        if l == 1 && show_header
-            bottom = if nrows < 2
-                :bottom
-            elseif nrows > 2
-                :row
+        if l == 1
+            if show_header
+                bottom = if nrows < 2
+                    :bottom
+                elseif nrows > 2
+                    :row
+                else
+                    :foot_row
+                end
+                top = show_header ? nothing : :top
+                mid = :mid
+                _compact = (show_header && (box != BOXES[:NONE])) ? false : compact
             else
-                :foot_row
+                top, mid, bottom, _compact = :top, :mid, :row, compact
             end
-            top = show_header ? nothing : :top
-            mid = :mid
-            _compact = (show_header && (box != BOXES[:NONE])) ? false : compact
-
-            # add additional rows
         elseif l == nrows
             top, mid, bottom, _compact =
                 nothing, :mid, isnothing(footer) ? :bottom : :foot_row, false


### PR DESCRIPTION
Issue #242

Change so that top border of Table box is drawn when show_header=false

```
julia> data = reshape(1:12, 3, 4)
3×4 reshape(::UnitRange{Int64}, 3, 4) with eltype Int64:
 1  4  7  10
 2  5  8  11
 3  6  9  12
```

Before:
```
julia> Table(data; box=:ROUNDED, show_header=false)
│  1  │  4  │  7  │  10  │
├─────┼─────┼─────┼──────┤
│  2  │  5  │  8  │  11  │
├─────┼─────┼─────┼──────┤
│  3  │  6  │  9  │  12  │
╰─────┴─────┴─────┴──────╯
```

After:
```
julia> Table(data; box=:ROUNDED, show_header=false)
╭─────┬─────┬─────┬──────╮
│  1  │  4  │  7  │  10  │
├─────┼─────┼─────┼──────┤
│  2  │  5  │  8  │  11  │
├─────┼─────┼─────┼──────┤
│  3  │  6  │  9  │  12  │
╰─────┴─────┴─────┴──────╯
```
