### PR TITLE
Support creating Table from arbitrary types

### DIFF
--- a/src/tables.jl
+++ b/src/tables.jl
@@ -306,6 +306,23 @@ Table(data::AbstractDict; header = nothing, kwargs...) = Table(
     kwargs...,
 )
 
+""" 
+Table(data::T; kwargs...) where T
+
+Construct `Table` from an object of type T if the type supports the `Tables` interface.
+Specifically, a `Table` is constructed if `istable(T)` returns true, otherwise an `ArgumentError` is thrown.
+The column names of the object make up the table header if none is assigned.
+"""
+function Table(data::T; header = nothing, kwargs...) where T
+    if TablesPkg.istable(T)
+        columns = TablesPkg.Columns(data)
+        header = isnothing(header) ? string.(TablesPkg.columnnames(columns)) : header
+        Table(columns; header, kwargs...)
+    else 
+        throw(ArgumentError("type $T does not support Tables interface"))
+    end
+end
+
 """
     function table_row(
         cells::Vector,


### PR DESCRIPTION
Allow creating `Term.Table` from arbitrary types that support the `Tables.jl` interface.

Specifically, a `Table` is constructed if `istable(T)` returns true, otherwise an `ArgumentError` is thrown.
The column names of the object make up the table header if none is assigned.

Fixes #239
