### PR TITLE
Per-Job Columns

### DIFF
--- a/src/progress.jl
+++ b/src/progress.jl
@@ -337,7 +337,8 @@ Base.show(io::IO, ::MIME"text/plain", pbar::ProgressBar) =
             N::Union{Int, Nothing}=nothing,
             start::Bool=true,
             transient::Bool=false,
-            id=nothing
+            id=nothing,
+            columns::Vector{DataType} = pbar.columns
         )::ProgressJob
 
 Add a new `ProgressJob` to a running `ProgressBar`
@@ -352,6 +353,7 @@ function addjob!(
     transient::Bool = false,
     id = nothing,
     columns_kwargs::Dict = Dict(),
+    columns::Vector{DataType} = pbar.columns,
 )::ProgressJob
     pbar.running && print("\n")
 
@@ -359,7 +361,7 @@ function addjob!(
     pbar.paused = true
     id = isnothing(id) ? length(pbar.jobs) + 1 : id
     kwargs = merge(pbar.columns_kwargs, columns_kwargs)
-    job = ProgressJob(id, N, description, pbar.columns, pbar.width, kwargs, transient)
+    job = ProgressJob(id, N, description, columns, pbar.width, kwargs, transient)
 
     # start job
     start && start!(job)

--- a/test/15_test_progress.jl
+++ b/test/15_test_progress.jl
@@ -2,7 +2,12 @@ using Term.Progress
 import Term.Progress: AbstractColumn, getjob, get_columns, jobcolor
 import Term: install_term_logger, uninstall_term_logger, str_trunc
 import Term.Progress:
-    CompletedColumn, SeparatorColumn, ProgressColumn, DescriptionColumn, TextColumn, SpinnerColumn
+    CompletedColumn,
+    SeparatorColumn,
+    ProgressColumn,
+    DescriptionColumn,
+    TextColumn,
+    SpinnerColumn
 
 using ProgressLogging
 import ProgressLogging.Logging.global_logger
@@ -138,19 +143,19 @@ end
 
 @testset "\e[34mProgress per-job columns" begin
     @test_nowarn redirect_stdout(Base.DevNull()) do
-        p = ProgressBar(; columns=:default)
+        p = ProgressBar(; columns = :default)
         c0 = [DescriptionColumn, CompletedColumn, ProgressColumn, SpinnerColumn]
         c1 = [DescriptionColumn, CompletedColumn, ProgressColumn, SpinnerColumn]
-        c2 = [CompletedColumn,   ProgressColumn, SeparatorColumn, SpinnerColumn]
-        j0 = addjob!(p; columns=c0, N=100)
-        j1 = addjob!(p; columns=c1, N=100)
-        j2 = addjob!(p; columns=c2, N=100)
+        c2 = [CompletedColumn, ProgressColumn, SeparatorColumn, SpinnerColumn]
+        j0 = addjob!(p; columns = c0, N = 100)
+        j1 = addjob!(p; columns = c1, N = 100)
+        j2 = addjob!(p; columns = c2, N = 100)
         @test all(typeof.(j0.columns) .== c0)
         @test all(typeof.(j1.columns) .== c1)
         @test all(typeof.(j2.columns) .== c2)
         @test !all(typeof.(j2.columns) .== c0)
         @test !all(typeof.(j0.columns) .== c2)
-        
+
         with(p) do
             for _ in 1:100
                 update!(j0)

--- a/test/15_test_progress.jl
+++ b/test/15_test_progress.jl
@@ -2,7 +2,7 @@ using Term.Progress
 import Term.Progress: AbstractColumn, getjob, get_columns, jobcolor
 import Term: install_term_logger, uninstall_term_logger, str_trunc
 import Term.Progress:
-    CompletedColumn, SeparatorColumn, ProgressColumn, DescriptionColumn, TextColumn
+    CompletedColumn, SeparatorColumn, ProgressColumn, DescriptionColumn, TextColumn, SpinnerColumn
 
 using ProgressLogging
 import ProgressLogging.Logging.global_logger

--- a/test/15_test_progress.jl
+++ b/test/15_test_progress.jl
@@ -136,6 +136,32 @@ end
     IS_WIN || @compare_to_string render(pbar) "pbar_customization"
 end
 
+@testset "\e[34mProgress per-job columns" begin
+    @test_nowarn redirect_stdout(Base.DevNull()) do
+        p = ProgressBar(; columns=:default)
+        c0 = [DescriptionColumn, CompletedColumn, ProgressColumn, SpinnerColumn]
+        c1 = [DescriptionColumn, CompletedColumn, ProgressColumn, SpinnerColumn]
+        c2 = [CompletedColumn,   ProgressColumn, SeparatorColumn, SpinnerColumn]
+        j0 = addjob!(p; columns=c0, N=100)
+        j1 = addjob!(p; columns=c1, N=100)
+        j2 = addjob!(p; columns=c2, N=100)
+        @test all(typeof.(j0.columns) .== c0)
+        @test all(typeof.(j1.columns) .== c1)
+        @test all(typeof.(j2.columns) .== c2)
+        @test !all(typeof.(j2.columns) .== c0)
+        @test !all(typeof.(j0.columns) .== c2)
+        
+        with(p) do
+            for _ in 1:100
+                update!(j0)
+                update!(j1)
+                update!(j2)
+                sleep(0.01)
+            end
+        end
+    end
+end
+
 @testset "\e[34mProgress foreachprogress" begin
     @test_nowarn redirect_stdout(Base.DevNull()) do
         Term.Progress.foreachprogress(1:10) do i


### PR DESCRIPTION
Some tasks are best represented with different states -- e.g. one may be iterating over a collection, whilst another may be doing I/O and metering bytes per second, within the context of one ProgressBar() object.

This micro-PR allows for specification of ProgressJob columns at the point of addjob!() invocation. A minimal, arbitrary example:

```julia
p = ProgressBar(; columns=:default)
c1 = [DescriptionColumn, SeparatorColumn,  ProgressColumn, SpinnerColumn]
c2 = [CompletedColumn,   ProgressColumn, SeparatorColumn, SpinnerColumn]

with(p) do
    j1 = addjob!(p; columns=c1, N=100)
    j2 = addjob!(p; columns=c2, N=100)
    for _ in 1:100
        update!.([j1, j2])
        sleep(0.01)
    end
end
```