### PR TITLE
On-the-fly ProgressJob reconfiguration with swapjob!()

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,9 +26,17 @@ jobs:
           - '1' # latest stable release
         experimental:
           - false
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
         arch: [x64]
-        include:
+        include:  # NOTE: macos-latest resolves to macos-14 (only aarch64)
+          - os: macos-latest
+            experimental: false
+            arch: aarch64
+            version: 'lts'
+          - os: macos-latest
+            experimental: false
+            arch: aarch64
+            version: '1'
           - os: ubuntu-latest
             experimental: true
             version: 'pre'
@@ -43,6 +51,7 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+        timeout-minutes: 20
       - uses: julia-actions/julia-processcoverage@latest
       - uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         version:
           - '1.6'  # oldest LTS supported
-          - '1.10'
+          - 'lts'
           - '1' # latest stable release
         experimental:
           - false
@@ -33,10 +33,7 @@ jobs:
             experimental: true
             version: 'pre'
             arch: x64
-          - os: ubuntu-latest
-            experimental: true
-            version: 'nightly'
-            arch: x64
+
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@latest

--- a/docs/src/adv/progressbars.md
+++ b/docs/src/adv/progressbars.md
@@ -298,34 +298,35 @@ As an example, we will generate three tasks with no bound. At different points i
 import Term.Progress: DescriptionColumn, SeparatorColumn, CompletedColumn, ProgressColumn, SpinnerColumn
 
 # make a progress bar, and add three jobs.
-p  = ProgressBar(; title = "swapjob!() Demo")
-j1 = addjob!(p; description="[1]: No N bound...")
-j2 = addjob!(p; description="[2]: No N bound...", transient = true)
-j3 = addjob!(p; description="[3]: No N bound...")
+let p  = ProgressBar(; title = "swapjob!() Demo")
+    j1 = addjob!(p; description="[1]: No N bound...")
+    j2 = addjob!(p; description="[2]: No N bound...", transient = true)
+    j3 = addjob!(p; description="[3]: No N bound...")
 
-# when we switch on limits, we will add these columns to each ProgressJob.
-cols = [DescriptionColumn, SeparatorColumn, CompletedColumn,
-        SeparatorColumn, ProgressColumn, SeparatorColumn, SpinnerColumn]
+    # when we switch on limits, we will add these columns to each ProgressJob.
+    cols = [DescriptionColumn, SeparatorColumn, CompletedColumn,
+            SeparatorColumn, ProgressColumn, SeparatorColumn, SpinnerColumn]
 
-with(p) do
-    for i in 1:300
+    with(p) do
+        for i in 1:300
 
-        # invoke swapjob!() to change displays on-the-fly.
-        if i == 50
-            j1 = swapjob!(p, j1; N=300, description = "[1]: N bounded", columns = cols)
-        end
-        if i == 150
-            j2 = swapjob!(p, j2; N=200, description = "[2]: N bounded", columns = cols)
-        end
-        if i == 200
-            j3 = swapjob!(p, j3; N=300, description = "[3]: N bounded", columns = cols)
-        end
-        if i == 250
-            j1 = swapjob!(p, j1, description = "[1]: Lost bound!", N=nothing, inherit = true)
-        end
+            # invoke swapjob!() to change displays on-the-fly.
+            if i == 50
+                j1 = swapjob!(p, j1; N=300, description = "[1]: N bounded", columns = cols)
+            end
+            if i == 150
+                j2 = swapjob!(p, j2; N=200, description = "[2]: N bounded", columns = cols)
+            end
+            if i == 200
+                j3 = swapjob!(p, j3; N=300, description = "[3]: N bounded", columns = cols)
+            end
+            if i == 250
+                j1 = swapjob!(p, j1, description = "[1]: Lost bound!", N=nothing, inherit = true)
+            end
 
-        update!.([j1, j2, j3])
-        sleep(0.02)
+            update!.([j1, j2, j3])
+            sleep(0.02)
+        end
     end
 end
 ```

--- a/docs/src/adv/progressbars.md
+++ b/docs/src/adv/progressbars.md
@@ -305,7 +305,7 @@ j3 = addjob!(p; description="[3]: No N bound...")
 
 # when we switch on limits, we will add these columns to each ProgressJob.
 cols = [DescriptionColumn, SeparatorColumn, CompletedColumn,
-        SeparatorColumn, ProgressColumn, SeparatorColumn, SpinnerColumn])
+        SeparatorColumn, ProgressColumn, SeparatorColumn, SpinnerColumn]
 
 with(p) do
     for i in 1:300

--- a/src/progress.jl
+++ b/src/progress.jl
@@ -414,31 +414,34 @@ Fields of the new job are populated with the following priority:
     3. Default settings as in `addjob!()`.
 """
 function swapjob!(
-    pbar           :: ProgressBar,
-    jobid          :: Union{ProgressJob, Int, UUID};
-    description    :: Union{String,Missing}            = missing,
-    N              :: Union{Int,Nothing,Missing}       = missing,
-    i              :: Union{Int,Missing}               = missing,
-    columns        :: Union{Vector{DataType}, Missing} = missing,
-    columns_kwargs :: Union{Dict, Missing}             = missing,
-    transient      :: Union{Bool,Missing}              = missing,
-    start          :: Bool                             = true,
-    inherit        :: Bool                             = true,
+    pbar::ProgressBar,
+    jobid::Union{ProgressJob,Int,UUID};
+    description::Union{String,Missing}       = missing,
+    N::Union{Int,Nothing,Missing}            = missing,
+    i::Union{Int,Missing}                    = missing,
+    columns::Union{Vector{DataType},Missing} = missing,
+    columns_kwargs::Union{Dict,Missing}      = missing,
+    transient::Union{Bool,Missing}           = missing,
+    start::Bool                              = true,
+    inherit::Bool                            = true,
 )::ProgressJob
 
     # get the job ID and ensure that it is present in the list of progress bar jobs
     jobid = jobid isa ProgressJob ? jobid.id : jobid
     index = findfirst(j -> j.id == jobid, pbar.jobs)
-    isnothing(index) &&
-        throw(ArgumentError("ID $jobid is not a valid job ID. Registered jobs: $([j.id for j in pbar.jobs])"))
+    isnothing(index) && throw(
+        ArgumentError(
+            "ID $jobid is not a valid job ID. Registered jobs: $([j.id for j in pbar.jobs])",
+        ),
+    )
 
     # set parameters from function arguments, old job, and defaults.
-    @__swapjob_inherit! description     pbar.jobs[index].description       "Running..."
-    @__swapjob_inherit! N               pbar.jobs[index].N                 nothing
-    @__swapjob_inherit! i               pbar.jobs[index].i                 0
-    @__swapjob_inherit! columns         typeof.(pbar.jobs[index].columns)  pbar.columns
-    @__swapjob_inherit! columns_kwargs  pbar.jobs[index].columns_kwargs    Dict()
-    @__swapjob_inherit! transient       pbar.jobs[index].transient         false
+    @__swapjob_inherit! description pbar.jobs[index].description "Running..."
+    @__swapjob_inherit! N pbar.jobs[index].N nothing
+    @__swapjob_inherit! i pbar.jobs[index].i 0
+    @__swapjob_inherit! columns typeof.(pbar.jobs[index].columns) pbar.columns
+    @__swapjob_inherit! columns_kwargs pbar.jobs[index].columns_kwargs Dict()
+    @__swapjob_inherit! transient pbar.jobs[index].transient false
 
     # stop the bar and mix in any new column keyword arguments
     pbar.paused = true
@@ -449,7 +452,7 @@ function swapjob!(
     job.i = i
     start && start!(job)
     pbar.jobs[index] = job
-    
+
     # render and return
     pbar.paused = false
     render(pbar.jobs[index], pbar)

--- a/src/progress.jl
+++ b/src/progress.jl
@@ -252,6 +252,7 @@ Arguments:
     - `paused`: false when the bar is running but briefly paused (e.g. to update `jobs`)
     - `task`: references a `Task` for updating the progress bar in parallel
     - `renderstatus`: a `RenderStatus` instance
+    - `title`: progress bar title
     - `extra_info`: a `Dict{String,<:Any}` to show extra information.
 """
 mutable struct ProgressBar
@@ -271,6 +272,7 @@ mutable struct ProgressBar
     task::Union{Task,Nothing}
     renderstatus::Any
     extra_info::Dict{String,<:Any}
+    title::String
 end
 
 """
@@ -300,6 +302,7 @@ function ProgressBar(;
     colors::Union{String,Vector{RGBColor}}  = [RGBColor("(1, .05, .05)"), RGBColor("(.05, .05, 1)"), RGBColor("(.05, 1, .05)")],
     refresh_rate::Int                       = 60,  # FPS of rendering
     extra_info::Dict{String,<:Any}          = Dict{String,Any}(),
+    title                                   = "progress",
 )
     columns = columns isa Symbol ? get_columns(columns) : columns
 
@@ -320,6 +323,7 @@ function ProgressBar(;
         nothing,
         RenderStatus(),
         extra_info,
+        title,
     )
 end
 
@@ -503,7 +507,7 @@ function render(pbar::ProgressBar, io = stdout)
 
         pbar.renderstatus.rendered = true
         pbar.renderstatus.hline =
-            string(hLine(pbar.width, "progress"; style = "blue dim")) * "\n"
+            string(hLine(pbar.width, pbar.title; style = "blue dim")) * "\n"
         pbar.renderstatus.nlines = njobs
         pbar.renderstatus.maxnlines = njobs
 

--- a/src/progress.jl
+++ b/src/progress.jl
@@ -382,14 +382,16 @@ macro __swapjob_inherit!(param, old, default)
 end
 
 """
-    swapjob!(pbar::ProgressBar,                                                                      
-             jobid::Union{ProgressJob, Int, UUID};                                                   
-             description::String       = jobid isa ProgressJob ? jobid.description    : "Running...",
-             N::Union{Int,Nothing}     = jobid isa ProgressJob ? jobid.N              : nothing,     
-             columns::Vector{DataType} = jobid isa ProgressJob ? jobid.columns        : pbar.columns,
-             columns_kwargs::Dict      = jobid isa ProgressJob ? jobid.columns_kwargs : Dict(),      
-             transient::Bool           = jobid isa ProgressJob ? jobid.transient      : false,       
-             start::Bool = true,                                                                     
+    swapjob!(pbar           :: ProgressBar,                               
+             jobid          :: Union{ProgressJob, Int, UUID};             
+             description    :: Union{String,Missing}            = missing,
+             N              :: Union{Int,Nothing,Missing}       = missing,
+             i              :: Union{Int,Missing}               = missing,
+             columns        :: Union{Vector{DataType}, Missing} = missing,
+             columns_kwargs :: Union{Dict, Missing}             = missing,
+             transient      :: Union{Bool,Missing}              = missing,
+             start          :: Bool                             = true,   
+             inherit        :: Bool                             = true,   
              )::ProgressJob                                                                          
 
 Change progress jobs on-the-fly; returns the newly-constructed `ProgressJob`.

--- a/src/progress.jl
+++ b/src/progress.jl
@@ -34,6 +34,7 @@ export ProgressBar,
     start!,
     stop!,
     update!,
+    swapjob!,
     removejob!,
     with,
     @track,
@@ -367,6 +368,84 @@ function addjob!(
     pbar.paused = false
     render(job, pbar)
     return job
+end
+
+"""
+    @__swapjob_inherit!(param, old, default)
+inherit from the old job with the priority scheme as given in the description
+of swapjob!() below. the macro allows us to assign to the parameter, which an
+ordinary closure can't do. unfortunately macros are not allowed outside of
+toplevel scope, so it has to live here at toplevel.
+"""
+macro __swapjob_inherit!(param, old, default)
+    esc(:($param = !ismissing($param) ? $param : (inherit ? $old : $default)))
+end
+
+"""
+    swapjob!(pbar::ProgressBar,                                                                      
+             jobid::Union{ProgressJob, Int, UUID};                                                   
+             description::String       = jobid isa ProgressJob ? jobid.description    : "Running...",
+             N::Union{Int,Nothing}     = jobid isa ProgressJob ? jobid.N              : nothing,     
+             columns::Vector{DataType} = jobid isa ProgressJob ? jobid.columns        : pbar.columns,
+             columns_kwargs::Dict      = jobid isa ProgressJob ? jobid.columns_kwargs : Dict(),      
+             transient::Bool           = jobid isa ProgressJob ? jobid.transient      : false,       
+             start::Bool = true,                                                                     
+             )::ProgressJob                                                                          
+
+Change progress jobs on-the-fly; returns the newly-constructed `ProgressJob`.
+
+The new progress job inherits the job ID of the old process. This allows
+for a progress job which represents an ongoing task to change form appropriate
+to the current task state. The job to replace can be specified either by a
+`ProgressJob` structure or a job ID. An ArgumentError will be thrown if the
+job ID is not found.
+
+Fields of the new job are populated with the following priority:
+    1. Arguments passed to `swapjob!()`,
+    2. Fields of the prior job (if the kwarg `inherit` is true),
+    3. Default settings as in `addjob!()`.
+"""
+function swapjob!(
+    pbar           :: ProgressBar,
+    jobid          :: Union{ProgressJob, Int, UUID};
+    description    :: Union{String,Missing}            = missing,
+    N              :: Union{Int,Nothing,Missing}       = missing,
+    i              :: Union{Int,Missing}               = missing,
+    columns        :: Union{Vector{DataType}, Missing} = missing,
+    columns_kwargs :: Union{Dict, Missing}             = missing,
+    transient      :: Union{Bool,Missing}              = missing,
+    start          :: Bool                             = true,
+    inherit        :: Bool                             = true,
+)::ProgressJob
+
+    # get the job ID and ensure that it is present in the list of progress bar jobs
+    jobid = jobid isa ProgressJob ? jobid.id : jobid
+    index = findfirst(j -> j.id == jobid, pbar.jobs)
+    isnothing(index) &&
+        throw(ArgumentError("ID $jobid is not a valid job ID. Registered jobs: $([j.id for j in pbar.jobs])"))
+
+    # set parameters from function arguments, old job, and defaults.
+    @__swapjob_inherit! description     pbar.jobs[index].description       "Running..."
+    @__swapjob_inherit! N               pbar.jobs[index].N                 nothing
+    @__swapjob_inherit! i               pbar.jobs[index].i                 0
+    @__swapjob_inherit! columns         typeof.(pbar.jobs[index].columns)  pbar.columns
+    @__swapjob_inherit! columns_kwargs  pbar.jobs[index].columns_kwargs    Dict()
+    @__swapjob_inherit! transient       pbar.jobs[index].transient         false
+
+    # stop the bar and mix in any new column keyword arguments
+    pbar.paused = true
+    kwargs      = merge(pbar.columns_kwargs, columns_kwargs)
+
+    # build the job and start it
+    job = ProgressJob(jobid, N, description, columns, pbar.width, kwargs, transient)
+    job.i = i
+    start && start!(job)
+    pbar.jobs[index] = job
+    
+    # render and return
+    pbar.paused = false
+    render(pbar.jobs[index], pbar)
+    return pbar.jobs[index]
 end
 
 """

--- a/src/progress.jl
+++ b/src/progress.jl
@@ -253,6 +253,7 @@ Arguments:
     - `paused`: false when the bar is running but briefly paused (e.g. to update `jobs`)
     - `task`: references a `Task` for updating the progress bar in parallel
     - `renderstatus`: a `RenderStatus` instance
+    - `title`: progress bar title
     - `extra_info`: a `Dict{String,<:Any}` to show extra information.
 """
 mutable struct ProgressBar
@@ -272,6 +273,7 @@ mutable struct ProgressBar
     task::Union{Task,Nothing}
     renderstatus::Any
     extra_info::Dict{String,<:Any}
+    title::String
 end
 
 """
@@ -301,6 +303,7 @@ function ProgressBar(;
     colors::Union{String,Vector{RGBColor}}  = [RGBColor("(1, .05, .05)"), RGBColor("(.05, .05, 1)"), RGBColor("(.05, 1, .05)")],
     refresh_rate::Int                       = 60,  # FPS of rendering
     extra_info::Dict{String,<:Any}          = Dict{String,Any}(),
+    title                                   = "progress",
 )
     columns = columns isa Symbol ? get_columns(columns) : columns
 
@@ -321,6 +324,7 @@ function ProgressBar(;
         nothing,
         RenderStatus(),
         extra_info,
+        title,
     )
 end
 
@@ -584,7 +588,7 @@ function render(pbar::ProgressBar, io = stdout)
 
         pbar.renderstatus.rendered = true
         pbar.renderstatus.hline =
-            string(hLine(pbar.width, "progress"; style = "blue dim")) * "\n"
+            string(hLine(pbar.width, pbar.title; style = "blue dim")) * "\n"
         pbar.renderstatus.nlines = njobs
         pbar.renderstatus.maxnlines = njobs
 

--- a/src/progress.jl
+++ b/src/progress.jl
@@ -337,7 +337,8 @@ Base.show(io::IO, ::MIME"text/plain", pbar::ProgressBar) =
             N::Union{Int, Nothing}=nothing,
             start::Bool=true,
             transient::Bool=false,
-            id=nothing
+            id=nothing,
+            columns::Vector{DataType} = pbar.columns
         )::ProgressJob
 
 Add a new `ProgressJob` to a running `ProgressBar`
@@ -352,6 +353,7 @@ function addjob!(
     transient::Bool = false,
     id = nothing,
     columns_kwargs::Dict = Dict(),
+    columns::Vector{DataType} = pbar.columns,
 )::ProgressJob
     pbar.running && print("\n")
 
@@ -359,7 +361,7 @@ function addjob!(
     pbar.paused = true
     id = isnothing(id) ? length(pbar.jobs) + 1 : id
     kwargs = merge(pbar.columns_kwargs, columns_kwargs)
-    job = ProgressJob(id, N, description, pbar.columns, pbar.width, kwargs, transient)
+    job = ProgressJob(id, N, description, columns, pbar.width, kwargs, transient)
 
     # start job
     start && start!(job)

--- a/test/15_test_progress.jl
+++ b/test/15_test_progress.jl
@@ -67,6 +67,17 @@ end
     end
 
     @test_nothrow begin
+        pbar3 = ProgressBar(; title = "Test")
+        with(pbar3) do
+            job = addjob!(pbar3; N = 10)
+            for i in 1:10
+                update!(job)
+                sleep(0.001)
+            end
+        end
+    end
+
+    @test_nothrow begin
         @track for i in 1:10
             sleep(0.001)
         end

--- a/test/15_test_progress.jl
+++ b/test/15_test_progress.jl
@@ -201,7 +201,7 @@ end
     let p = ProgressBar(; title = "swapjob!(): lookup by ID")
         j1 = addjob!(p; description="[1]: No N bound...")
         j2 = addjob!(p; description="[2]: No N bound...", id = uuid1())
-        j3 = addjob!(p; description="[3]: No N bound...", id = uuid7())
+        j3 = addjob!(p; description="[3]: No N bound...", id = uuid1())
         with(p) do
             for i in 1:300
                 if i == 50

--- a/test/15_test_progress.jl
+++ b/test/15_test_progress.jl
@@ -195,10 +195,10 @@ end
 
     # three bars, with state inheritance.
     @test_nowarn let p = ProgressBar(; title = "swapjob!(): multiple bars")
+        with(p) do
         j1 = addjob!(p; description="[1]: No N bound...")
         j2 = addjob!(p; description="[2]: No N bound...")
         j3 = addjob!(p; description="[3]: No N bound...")
-        with(p) do
             for i in 1:300
                 if i == 50
                     j1 = swapjob!(p, j1; N=300, description = "[1]: N bounded", inherit = true,
@@ -225,10 +225,10 @@ end
     # three bars, with state inheritance, mixed ID types, lookup by ID,
     # addition and removal of ProgressColumn when N is set or unset
     let p = ProgressBar(; title = "swapjob!(): lookup by ID")
-        j1 = addjob!(p; description="[1]: No N bound...")
-        j2 = addjob!(p; description="[2]: No N bound...", id = uuid1())
-        j3 = addjob!(p; description="[3]: No N bound...", id = uuid1())
         with(p) do
+            j1 = addjob!(p; description="[1]: No N bound...")
+            j2 = addjob!(p; description="[2]: No N bound...", id = uuid1())
+            j3 = addjob!(p; description="[3]: No N bound...", id = uuid1())
             for i in 1:300
                 if i == 50
                     j1 = swapjob!(p, j1.id; N=300, description = "[1]: N bounded", inherit = true,
@@ -269,10 +269,10 @@ end
 
     # three bars, second is transient and finishes early.
     @test_nothrow let p = ProgressBar(; title = "swapjob!(): Test early-finishing bar with inherited transience")
-        j1 = addjob!(p; description="[1]: No N bound...")
-        j2 = addjob!(p; description="[2]: No N bound...", id = uuid1(), transient = true)
-        j3 = addjob!(p; description="[3]: No N bound...", id = uuid7())
         with(p) do
+            j1 = addjob!(p; description="[1]: No N bound...")
+            j2 = addjob!(p; description="[2]: No N bound...", id = uuid1(), transient = true)
+            j3 = addjob!(p; description="[3]: No N bound...", id = uuid7())
             for i in 1:300
                 if i == 50
                     j1 = swapjob!(p, j1.id; N=300, description = "[1]: N bounded", inherit = true,
@@ -319,8 +319,6 @@ end
     end
 end
 
-
->>>>>>> swapjob
 @testset "\e[34mProgress foreachprogress" begin
     @test_nowarn redirect_stdout(Base.DevNull()) do
         Term.Progress.foreachprogress(1:10) do i

--- a/test/15_test_progress.jl
+++ b/test/15_test_progress.jl
@@ -65,6 +65,17 @@ end
     end
 
     @test_nothrow begin
+        pbar3 = ProgressBar(; title = "Test")
+        with(pbar3) do
+            job = addjob!(pbar3; N = 10)
+            for i in 1:10
+                update!(job)
+                sleep(0.001)
+            end
+        end
+    end
+
+    @test_nothrow begin
         @track for i in 1:10
             sleep(0.001)
         end

--- a/test/15_test_progress.jl
+++ b/test/15_test_progress.jl
@@ -227,8 +227,8 @@ end
     let p = ProgressBar(; title = "swapjob!(): lookup by ID")
         with(p) do
             j1 = addjob!(p; description="[1]: No N bound...")
-            j2 = addjob!(p; description="[2]: No N bound...", id = uuid1())
-            j3 = addjob!(p; description="[3]: No N bound...", id = uuid1())
+            j2 = addjob!(p; description="[2]: No N bound...", id = uuid4())
+            j3 = addjob!(p; description="[3]: No N bound...", id = uuid4())
             for i in 1:300
                 if i == 50
                     j1 = swapjob!(p, j1.id; N=300, description = "[1]: N bounded", inherit = true,
@@ -271,8 +271,8 @@ end
     @test_nothrow let p = ProgressBar(; title = "swapjob!(): Test early-finishing bar with inherited transience")
         with(p) do
             j1 = addjob!(p; description="[1]: No N bound...")
-            j2 = addjob!(p; description="[2]: No N bound...", id = uuid1(), transient = true)
-            j3 = addjob!(p; description="[3]: No N bound...", id = uuid7())
+            j2 = addjob!(p; description="[2]: No N bound...", id = uuid4(), transient = true)
+            j3 = addjob!(p; description="[3]: No N bound...", id = uuid4())
             for i in 1:300
                 if i == 50
                     j1 = swapjob!(p, j1.id; N=300, description = "[1]: N bounded", inherit = true,
@@ -294,7 +294,7 @@ end
                     j1 = swapjob!(p, j1.id, description = "[1]: Lost bound!", N=nothing, inherit = true)
                 end
                 update!.([j1, j2, j3])
-                sleep(0.002)
+                sleep(0.001)
             end
         end
     end

--- a/test/15_test_progress.jl
+++ b/test/15_test_progress.jl
@@ -2,7 +2,13 @@ using Term.Progress
 import Term.Progress: AbstractColumn, getjob, get_columns, jobcolor
 import Term: install_term_logger, uninstall_term_logger, str_trunc
 import Term.Progress:
-    CompletedColumn, SeparatorColumn, ProgressColumn, DescriptionColumn, TextColumn, SpinnerColumn, ETAColumn
+    CompletedColumn,
+    SeparatorColumn,
+    ProgressColumn,
+    DescriptionColumn,
+    TextColumn,
+    SpinnerColumn,
+    ETAColumn
 
 using ProgressLogging
 import ProgressLogging.Logging.global_logger
@@ -151,19 +157,19 @@ end
 
 @testset "\e[34mProgress per-job columns" begin
     @test_nowarn redirect_stdout(Base.DevNull()) do
-        p = ProgressBar(; columns=:default)
+        p = ProgressBar(; columns = :default)
         c0 = [DescriptionColumn, CompletedColumn, ProgressColumn, SpinnerColumn]
         c1 = [DescriptionColumn, CompletedColumn, ProgressColumn, SpinnerColumn]
-        c2 = [CompletedColumn,   ProgressColumn, SeparatorColumn, SpinnerColumn]
-        j0 = addjob!(p; columns=c0, N=100)
-        j1 = addjob!(p; columns=c1, N=100)
-        j2 = addjob!(p; columns=c2, N=100)
+        c2 = [CompletedColumn, ProgressColumn, SeparatorColumn, SpinnerColumn]
+        j0 = addjob!(p; columns = c0, N = 100)
+        j1 = addjob!(p; columns = c1, N = 100)
+        j2 = addjob!(p; columns = c2, N = 100)
         @test all(typeof.(j0.columns) .== c0)
         @test all(typeof.(j1.columns) .== c1)
         @test all(typeof.(j2.columns) .== c2)
         @test !all(typeof.(j2.columns) .== c0)
         @test !all(typeof.(j0.columns) .== c2)
-        
+
         with(p) do
             for _ in 1:100
                 update!(j0)
@@ -179,15 +185,27 @@ end
 
     # one bar.
     @test_nowarn let p = ProgressBar(; title = "swapjob!(): basic")
-        j = addjob!(p; description="No N bound...")
+        j = addjob!(p; description = "No N bound...")
         with(p) do
             for i in 1:100
                 if i == 50
-                    j = swapjob!(p, j; N=100, description = "N bounded",
-                                 columns = [DescriptionColumn, SeparatorColumn, CompletedColumn,
-                                            SeparatorColumn, ProgressColumn, SeparatorColumn, SpinnerColumn])
+                    j = swapjob!(
+                        p,
+                        j;
+                        N = 100,
+                        description = "N bounded",
+                        columns = [
+                            DescriptionColumn,
+                            SeparatorColumn,
+                            CompletedColumn,
+                            SeparatorColumn,
+                            ProgressColumn,
+                            SeparatorColumn,
+                            SpinnerColumn,
+                        ],
+                    )
                 end
-                update!(j; i=i)
+                update!(j; i = i)
                 sleep(0.005)
             end
         end
@@ -196,25 +214,64 @@ end
     # three bars, with state inheritance.
     @test_nowarn let p = ProgressBar(; title = "swapjob!(): multiple bars")
         with(p) do
-        j1 = addjob!(p; description="[1]: No N bound...")
-        j2 = addjob!(p; description="[2]: No N bound...")
-        j3 = addjob!(p; description="[3]: No N bound...")
+            j1 = addjob!(p; description = "[1]: No N bound...")
+            j2 = addjob!(p; description = "[2]: No N bound...")
+            j3 = addjob!(p; description = "[3]: No N bound...")
             for i in 1:300
                 if i == 50
-                    j1 = swapjob!(p, j1; N=300, description = "[1]: N bounded", inherit = true,
-                                  columns = [DescriptionColumn, SeparatorColumn, CompletedColumn,
-                                             SeparatorColumn, ProgressColumn, SeparatorColumn, SpinnerColumn])
+                    j1 = swapjob!(
+                        p,
+                        j1;
+                        N = 300,
+                        description = "[1]: N bounded",
+                        inherit = true,
+                        columns = [
+                            DescriptionColumn,
+                            SeparatorColumn,
+                            CompletedColumn,
+                            SeparatorColumn,
+                            ProgressColumn,
+                            SeparatorColumn,
+                            SpinnerColumn,
+                        ],
+                    )
                 end
                 if i == 150
-                    j2 = swapjob!(p, j2; N=300, description = "[2]: N bounded", inherit = true,
-                                  columns = [DescriptionColumn, SeparatorColumn, CompletedColumn,
-                                             SeparatorColumn, ProgressColumn, SeparatorColumn,
-                                             ETAColumn, SpinnerColumn])
+                    j2 = swapjob!(
+                        p,
+                        j2;
+                        N = 300,
+                        description = "[2]: N bounded",
+                        inherit = true,
+                        columns = [
+                            DescriptionColumn,
+                            SeparatorColumn,
+                            CompletedColumn,
+                            SeparatorColumn,
+                            ProgressColumn,
+                            SeparatorColumn,
+                            ETAColumn,
+                            SpinnerColumn,
+                        ],
+                    )
                 end
                 if i == 200
-                    j3 = swapjob!(p, j3; N=300, description = "[3]: N bounded", inherit = true,
-                                  columns = [DescriptionColumn, SeparatorColumn, CompletedColumn,
-                                             SeparatorColumn, ProgressColumn, SeparatorColumn, SpinnerColumn])
+                    j3 = swapjob!(
+                        p,
+                        j3;
+                        N = 300,
+                        description = "[3]: N bounded",
+                        inherit = true,
+                        columns = [
+                            DescriptionColumn,
+                            SeparatorColumn,
+                            CompletedColumn,
+                            SeparatorColumn,
+                            ProgressColumn,
+                            SeparatorColumn,
+                            SpinnerColumn,
+                        ],
+                    )
                 end
                 update!.([j1, j2, j3])
                 sleep(0.002)
@@ -226,37 +283,82 @@ end
     # addition and removal of ProgressColumn when N is set or unset
     let p = ProgressBar(; title = "swapjob!(): lookup by ID")
         with(p) do
-            j1 = addjob!(p; description="[1]: No N bound...")
-            j2 = addjob!(p; description="[2]: No N bound...", id = uuid4())
-            j3 = addjob!(p; description="[3]: No N bound...", id = uuid4())
+            j1 = addjob!(p; description = "[1]: No N bound...")
+            j2 = addjob!(p; description = "[2]: No N bound...", id = uuid4())
+            j3 = addjob!(p; description = "[3]: No N bound...", id = uuid4())
             for i in 1:300
                 if i == 50
-                    j1 = swapjob!(p, j1.id; N=300, description = "[1]: N bounded", inherit = true,
-                                  columns = [DescriptionColumn, SeparatorColumn, CompletedColumn,
-                                             SeparatorColumn, ProgressColumn, SeparatorColumn, SpinnerColumn])
+                    j1 = swapjob!(
+                        p,
+                        j1.id;
+                        N = 300,
+                        description = "[1]: N bounded",
+                        inherit = true,
+                        columns = [
+                            DescriptionColumn,
+                            SeparatorColumn,
+                            CompletedColumn,
+                            SeparatorColumn,
+                            ProgressColumn,
+                            SeparatorColumn,
+                            SpinnerColumn,
+                        ],
+                    )
                     @test ProgressColumn in typeof.(j1.columns)
                     @test !(ProgressColumn in typeof.(j2.columns))
                     @test !(ProgressColumn in typeof.(j3.columns))
                 end
                 if i == 150
-                    j2 = swapjob!(p, j2.id; N=300, description = "[2]: N bounded", inherit = true,
-                                  columns = [DescriptionColumn, SeparatorColumn, CompletedColumn,
-                                             SeparatorColumn, ProgressColumn, SeparatorColumn,
-                                             ETAColumn, SpinnerColumn])
+                    j2 = swapjob!(
+                        p,
+                        j2.id;
+                        N = 300,
+                        description = "[2]: N bounded",
+                        inherit = true,
+                        columns = [
+                            DescriptionColumn,
+                            SeparatorColumn,
+                            CompletedColumn,
+                            SeparatorColumn,
+                            ProgressColumn,
+                            SeparatorColumn,
+                            ETAColumn,
+                            SpinnerColumn,
+                        ],
+                    )
                     @test ProgressColumn in typeof.(j1.columns)
                     @test ProgressColumn in typeof.(j2.columns)
                     @test !(ProgressColumn in typeof.(j3.columns))
                 end
                 if i == 200
-                    j3 = swapjob!(p, j3.id; N=300, description = "[3]: N bounded", inherit = true,
-                                  columns = [DescriptionColumn, SeparatorColumn, CompletedColumn,
-                                             SeparatorColumn, ProgressColumn, SeparatorColumn, SpinnerColumn])
+                    j3 = swapjob!(
+                        p,
+                        j3.id;
+                        N = 300,
+                        description = "[3]: N bounded",
+                        inherit = true,
+                        columns = [
+                            DescriptionColumn,
+                            SeparatorColumn,
+                            CompletedColumn,
+                            SeparatorColumn,
+                            ProgressColumn,
+                            SeparatorColumn,
+                            SpinnerColumn,
+                        ],
+                    )
                     @test ProgressColumn in typeof.(j1.columns)
                     @test ProgressColumn in typeof.(j2.columns)
                     @test ProgressColumn in typeof.(j3.columns)
                 end
                 if i == 250
-                    j1 = swapjob!(p, j1.id, description = "[1]: Lost bound!", N=nothing, inherit = true)
+                    j1 = swapjob!(
+                        p,
+                        j1.id,
+                        description = "[1]: Lost bound!",
+                        N = nothing,
+                        inherit = true,
+                    )
                     @test !(ProgressColumn in typeof.(j1.columns))
                     @test ProgressColumn in typeof.(j2.columns)
                     @test ProgressColumn in typeof.(j3.columns)
@@ -268,30 +370,82 @@ end
     end
 
     # three bars, second is transient and finishes early.
-    @test_nothrow let p = ProgressBar(; title = "swapjob!(): Test early-finishing bar with inherited transience")
+    @test_nothrow let p = ProgressBar(;
+            title = "swapjob!(): Test early-finishing bar with inherited transience",
+        )
         with(p) do
-            j1 = addjob!(p; description="[1]: No N bound...")
-            j2 = addjob!(p; description="[2]: No N bound...", id = uuid4(), transient = true)
-            j3 = addjob!(p; description="[3]: No N bound...", id = uuid4())
+            j1 = addjob!(p; description = "[1]: No N bound...")
+            j2 = addjob!(
+                p;
+                description = "[2]: No N bound...",
+                id = uuid4(),
+                transient = true,
+            )
+            j3 = addjob!(p; description = "[3]: No N bound...", id = uuid4())
             for i in 1:300
                 if i == 50
-                    j1 = swapjob!(p, j1.id; N=300, description = "[1]: N bounded", inherit = true,
-                                  columns = [DescriptionColumn, SeparatorColumn, CompletedColumn,
-                                             SeparatorColumn, ProgressColumn, SeparatorColumn, SpinnerColumn])
+                    j1 = swapjob!(
+                        p,
+                        j1.id;
+                        N = 300,
+                        description = "[1]: N bounded",
+                        inherit = true,
+                        columns = [
+                            DescriptionColumn,
+                            SeparatorColumn,
+                            CompletedColumn,
+                            SeparatorColumn,
+                            ProgressColumn,
+                            SeparatorColumn,
+                            SpinnerColumn,
+                        ],
+                    )
                 end
                 if i == 150
-                    j2 = swapjob!(p, j2.id; N=200, description = "[2]: N bounded", inherit = true,
-                                  columns = [DescriptionColumn, SeparatorColumn, CompletedColumn,
-                                             SeparatorColumn, ProgressColumn, SeparatorColumn,
-                                             ETAColumn, SpinnerColumn])
+                    j2 = swapjob!(
+                        p,
+                        j2.id;
+                        N = 200,
+                        description = "[2]: N bounded",
+                        inherit = true,
+                        columns = [
+                            DescriptionColumn,
+                            SeparatorColumn,
+                            CompletedColumn,
+                            SeparatorColumn,
+                            ProgressColumn,
+                            SeparatorColumn,
+                            ETAColumn,
+                            SpinnerColumn,
+                        ],
+                    )
                 end
                 if i == 200
-                    j3 = swapjob!(p, j3.id; N=300, description = "[3]: N bounded", inherit = true,
-                                  columns = [DescriptionColumn, SeparatorColumn, CompletedColumn,
-                                             SeparatorColumn, ProgressColumn, SeparatorColumn, SpinnerColumn])
+                    j3 = swapjob!(
+                        p,
+                        j3.id;
+                        N = 300,
+                        description = "[3]: N bounded",
+                        inherit = true,
+                        columns = [
+                            DescriptionColumn,
+                            SeparatorColumn,
+                            CompletedColumn,
+                            SeparatorColumn,
+                            ProgressColumn,
+                            SeparatorColumn,
+                            SpinnerColumn,
+                        ],
+                    )
                 end
                 if i == 250
-                    j1 = swapjob!(p, j1.id, description = "[1]: Lost bound!", N=nothing, inherit = true)
+                    j1 = swapjob!(
+                        p,
+                        j1.id,
+                        description = "[1]: Lost bound!",
+                        N = nothing,
+                        inherit = true,
+                    )
                 end
                 update!.([j1, j2, j3])
                 sleep(0.001)

--- a/test/15_test_progress.jl
+++ b/test/15_test_progress.jl
@@ -2,10 +2,12 @@ using Term.Progress
 import Term.Progress: AbstractColumn, getjob, get_columns, jobcolor
 import Term: install_term_logger, uninstall_term_logger, str_trunc
 import Term.Progress:
-    CompletedColumn, SeparatorColumn, ProgressColumn, DescriptionColumn, TextColumn
+    CompletedColumn, SeparatorColumn, ProgressColumn, DescriptionColumn, TextColumn, SpinnerColumn, ETAColumn
 
 using ProgressLogging
 import ProgressLogging.Logging.global_logger
+
+using UUIDs
 
 @testset "\e[34mProgress - jobs" begin
     pbar = ProgressBar()
@@ -135,6 +137,157 @@ end
     start!(pbar)  # re-activate
     IS_WIN || @compare_to_string render(pbar) "pbar_customization"
 end
+
+using Test
+using Term
+using Term.Progress
+import Term.Progress:
+    CompletedColumn, SeparatorColumn, ProgressColumn, DescriptionColumn, TextColumn, SpinnerColumn, ETAColumn
+
+@testset "\e[34mProgress swapjob!()" begin
+
+    # one bar.
+    @test_nowarn let p = ProgressBar(; title = "swapjob!(): basic")
+        j = addjob!(p; description="No N bound...")
+        with(p) do
+            for i in 1:100
+                if i == 50
+                    j = swapjob!(p, j; N=100, description = "N bounded",
+                                 columns = [DescriptionColumn, SeparatorColumn, CompletedColumn,
+                                            SeparatorColumn, ProgressColumn, SeparatorColumn, SpinnerColumn])
+                end
+                update!(j; i=i)
+                sleep(0.05)
+            end
+        end
+    end
+
+    # three bars, with state inheritance.
+    @test_nowarn let p = ProgressBar(; title = "swapjob!(): multiple bars")
+        j1 = addjob!(p; description="[1]: No N bound...")
+        j2 = addjob!(p; description="[2]: No N bound...")
+        j3 = addjob!(p; description="[3]: No N bound...")
+        with(p) do
+            for i in 1:300
+                if i == 50
+                    j1 = swapjob!(p, j1; N=300, description = "[1]: N bounded", inherit = true,
+                                  columns = [DescriptionColumn, SeparatorColumn, CompletedColumn,
+                                             SeparatorColumn, ProgressColumn, SeparatorColumn, SpinnerColumn])
+                end
+                if i == 150
+                    j2 = swapjob!(p, j2; N=300, description = "[2]: N bounded", inherit = true,
+                                  columns = [DescriptionColumn, SeparatorColumn, CompletedColumn,
+                                             SeparatorColumn, ProgressColumn, SeparatorColumn,
+                                             ETAColumn, SpinnerColumn])
+                end
+                if i == 200
+                    j3 = swapjob!(p, j3; N=300, description = "[3]: N bounded", inherit = true,
+                                  columns = [DescriptionColumn, SeparatorColumn, CompletedColumn,
+                                             SeparatorColumn, ProgressColumn, SeparatorColumn, SpinnerColumn])
+                end
+                update!.([j1, j2, j3])
+                sleep(0.02)
+            end
+        end
+    end
+
+    # three bars, with state inheritance, mixed ID types, lookup by ID,
+    # addition and removal of ProgressColumn when N is set or unset
+    let p = ProgressBar(; title = "swapjob!(): lookup by ID")
+        j1 = addjob!(p; description="[1]: No N bound...")
+        j2 = addjob!(p; description="[2]: No N bound...", id = uuid1())
+        j3 = addjob!(p; description="[3]: No N bound...", id = uuid7())
+        with(p) do
+            for i in 1:300
+                if i == 50
+                    j1 = swapjob!(p, j1.id; N=300, description = "[1]: N bounded", inherit = true,
+                                  columns = [DescriptionColumn, SeparatorColumn, CompletedColumn,
+                                             SeparatorColumn, ProgressColumn, SeparatorColumn, SpinnerColumn])
+                    @test ProgressColumn in typeof.(j1.columns)
+                    @test !(ProgressColumn in typeof.(j2.columns))
+                    @test !(ProgressColumn in typeof.(j3.columns))
+                end
+                if i == 150
+                    j2 = swapjob!(p, j2.id; N=300, description = "[2]: N bounded", inherit = true,
+                                  columns = [DescriptionColumn, SeparatorColumn, CompletedColumn,
+                                             SeparatorColumn, ProgressColumn, SeparatorColumn,
+                                             ETAColumn, SpinnerColumn])
+                    @test ProgressColumn in typeof.(j1.columns)
+                    @test ProgressColumn in typeof.(j2.columns)
+                    @test !(ProgressColumn in typeof.(j3.columns))
+                end
+                if i == 200
+                    j3 = swapjob!(p, j3.id; N=300, description = "[3]: N bounded", inherit = true,
+                                  columns = [DescriptionColumn, SeparatorColumn, CompletedColumn,
+                                             SeparatorColumn, ProgressColumn, SeparatorColumn, SpinnerColumn])
+                    @test ProgressColumn in typeof.(j1.columns)
+                    @test ProgressColumn in typeof.(j2.columns)
+                    @test ProgressColumn in typeof.(j3.columns)
+                end
+                if i == 250
+                    j1 = swapjob!(p, j1.id, description = "[1]: Lost bound!", N=nothing, inherit = true)
+                    @test !(ProgressColumn in typeof.(j1.columns))
+                    @test ProgressColumn in typeof.(j2.columns)
+                    @test ProgressColumn in typeof.(j3.columns)
+                end
+                update!.([j1, j2, j3])
+                sleep(0.02)
+            end
+        end
+    end
+
+    # three bars, second is transient and finishes early.
+    @test_nothrow let p = ProgressBar(; title = "swapjob!(): Test early-finishing bar with inherited transience")
+        j1 = addjob!(p; description="[1]: No N bound...")
+        j2 = addjob!(p; description="[2]: No N bound...", id = uuid1(), transient = true)
+        j3 = addjob!(p; description="[3]: No N bound...", id = uuid7())
+        with(p) do
+            for i in 1:300
+                if i == 50
+                    j1 = swapjob!(p, j1.id; N=300, description = "[1]: N bounded", inherit = true,
+                                  columns = [DescriptionColumn, SeparatorColumn, CompletedColumn,
+                                             SeparatorColumn, ProgressColumn, SeparatorColumn, SpinnerColumn])
+                end
+                if i == 150
+                    j2 = swapjob!(p, j2.id; N=200, description = "[2]: N bounded", inherit = true,
+                                  columns = [DescriptionColumn, SeparatorColumn, CompletedColumn,
+                                             SeparatorColumn, ProgressColumn, SeparatorColumn,
+                                             ETAColumn, SpinnerColumn])
+                end
+                if i == 200
+                    j3 = swapjob!(p, j3.id; N=300, description = "[3]: N bounded", inherit = true,
+                                  columns = [DescriptionColumn, SeparatorColumn, CompletedColumn,
+                                             SeparatorColumn, ProgressColumn, SeparatorColumn, SpinnerColumn])
+                end
+                if i == 250
+                    j1 = swapjob!(p, j1.id, description = "[1]: Lost bound!", N=nothing, inherit = true)
+                end
+                update!.([j1, j2, j3])
+                sleep(0.02)
+            end
+        end
+    end
+
+    # see if we can get an argument error out
+    let p = ProgressBar(; title = "swapjob!(): throw error on bad ID")
+        u = uuid1()
+        v = uuid1()
+        j = addjob!(p; id = u)
+        u == v && error("ffs hahahahahahahahahaha")
+        with(p) do
+            update!(j)
+            @test_nowarn begin
+                j = swapjob!(p, u; N = 1000)
+            end
+            update!(j)
+            @test_throws ArgumentError begin
+                j = swapjob!(p, v; N = 2000)
+            end
+            update!(j)
+        end
+    end
+end
+
 
 @testset "\e[34mProgress foreachprogress" begin
     @test_nowarn redirect_stdout(Base.DevNull()) do

--- a/test/15_test_progress.jl
+++ b/test/15_test_progress.jl
@@ -2,7 +2,7 @@ using Term.Progress
 import Term.Progress: AbstractColumn, getjob, get_columns, jobcolor
 import Term: install_term_logger, uninstall_term_logger, str_trunc
 import Term.Progress:
-    CompletedColumn, SeparatorColumn, ProgressColumn, DescriptionColumn, TextColumn
+    CompletedColumn, SeparatorColumn, ProgressColumn, DescriptionColumn, TextColumn, SpinnerColumn
 
 using ProgressLogging
 import ProgressLogging.Logging.global_logger

--- a/test/15_test_progress.jl
+++ b/test/15_test_progress.jl
@@ -149,7 +149,6 @@ end
     IS_WIN || @compare_to_string render(pbar) "pbar_customization"
 end
 
-<<<<<<< HEAD
 @testset "\e[34mProgress per-job columns" begin
     @test_nowarn redirect_stdout(Base.DevNull()) do
         p = ProgressBar(; columns=:default)
@@ -176,7 +175,6 @@ end
     end
 end
 
-=======
 @testset "\e[34mProgress swapjob!()" begin
 
     # one bar.

--- a/test/15_test_progress.jl
+++ b/test/15_test_progress.jl
@@ -138,12 +138,6 @@ end
     IS_WIN || @compare_to_string render(pbar) "pbar_customization"
 end
 
-using Test
-using Term
-using Term.Progress
-import Term.Progress:
-    CompletedColumn, SeparatorColumn, ProgressColumn, DescriptionColumn, TextColumn, SpinnerColumn, ETAColumn
-
 @testset "\e[34mProgress swapjob!()" begin
 
     # one bar.

--- a/test/15_test_progress.jl
+++ b/test/15_test_progress.jl
@@ -136,6 +136,32 @@ end
     IS_WIN || @compare_to_string render(pbar) "pbar_customization"
 end
 
+@testset "\e[34mProgress per-job columns" begin
+    @test_nowarn redirect_stdout(Base.DevNull()) do
+        p = ProgressBar(; columns=:default)
+        c0 = [DescriptionColumn, CompletedColumn, ProgressColumn, SpinnerColumn]
+        c1 = [DescriptionColumn, CompletedColumn, ProgressColumn, SpinnerColumn]
+        c2 = [CompletedColumn,   ProgressColumn, SeparatorColumn, SpinnerColumn]
+        j0 = addjob!(p; columns=c0, N=100)
+        j1 = addjob!(p; columns=c1, N=100)
+        j2 = addjob!(p; columns=c2, N=100)
+        @test all(typeof.(j0.columns) .== c0)
+        @test all(typeof.(j1.columns) .== c1)
+        @test all(typeof.(j2.columns) .== c2)
+        @test !all(typeof.(j2.columns) .== c0)
+        @test !all(typeof.(j0.columns) .== c2)
+        
+        with(p) do
+            for _ in 1:100
+                update!(j0)
+                update!(j1)
+                update!(j2)
+                sleep(0.01)
+            end
+        end
+    end
+end
+
 @testset "\e[34mProgress foreachprogress" begin
     @test_nowarn redirect_stdout(Base.DevNull()) do
         Term.Progress.foreachprogress(1:10) do i

--- a/test/15_test_progress.jl
+++ b/test/15_test_progress.jl
@@ -151,7 +151,7 @@ end
                                             SeparatorColumn, ProgressColumn, SeparatorColumn, SpinnerColumn])
                 end
                 update!(j; i=i)
-                sleep(0.05)
+                sleep(0.005)
             end
         end
     end
@@ -180,7 +180,7 @@ end
                                              SeparatorColumn, ProgressColumn, SeparatorColumn, SpinnerColumn])
                 end
                 update!.([j1, j2, j3])
-                sleep(0.02)
+                sleep(0.002)
             end
         end
     end
@@ -225,7 +225,7 @@ end
                     @test ProgressColumn in typeof.(j3.columns)
                 end
                 update!.([j1, j2, j3])
-                sleep(0.02)
+                sleep(0.002)
             end
         end
     end
@@ -257,7 +257,7 @@ end
                     j1 = swapjob!(p, j1.id, description = "[1]: Lost bound!", N=nothing, inherit = true)
                 end
                 update!.([j1, j2, j3])
-                sleep(0.02)
+                sleep(0.002)
             end
         end
     end


### PR DESCRIPTION
This PR adds an additional function, `swapjob!()`, which is similar to `addjob!()` for progress bars, but allows for alteration of `ProgressJob` objects without displacing them from their location in the job list.

This interface is capable of many things:
* Switching between bounded (integer `N`) and unbounded (`N == nothing`) jobs, 
* Changing `N` or the description, and
* Changing column layouts on the fly.

This is particularly useful when a set of jobs are moving through a state machine, with their best representation changing over time. An example of this might be a thread pool, where each worker in sequence is given URLs to download: we may want the task list to move from an unbounded "connecting" message, to a bounded progress bar with new columns indicating download progress, to "complete" and "idle" messages, as tasks are distributed.

(In fact, that's exactly my use case!)

I have updated the documentation and tests; the full series of commits is in this PR.

Note that this PR is independent of my other pending PR, but has been rebased on top of recent master.

A minimal example is here:

```julia
using Term, Term.Progress
import Term.Progress: DescriptionColumn, SeparatorColumn, CompletedColumn, ProgressColumn, SpinnerColumn

# make a progress bar, and add three jobs.
let p  = ProgressBar(; title = "swapjob!() Demo")
    j1 = addjob!(p; description="[1]: No N bound...")
    j2 = addjob!(p; description="[2]: No N bound...", transient = true)
    j3 = addjob!(p; description="[3]: No N bound...")

    # when we switch on limits, we will add these columns to each ProgressJob.
    cols = [DescriptionColumn, SeparatorColumn, CompletedColumn,
            SeparatorColumn, ProgressColumn, SeparatorColumn, SpinnerColumn]

    with(p) do
        for i in 1:300

            # invoke swapjob!() to change displays on-the-fly.
            if i == 50
                j1 = swapjob!(p, j1; N=300, description = "[1]: N bounded", columns = cols)
            end
            if i == 150
                j2 = swapjob!(p, j2; N=200, description = "[2]: N bounded", columns = cols)
            end
            if i == 200
                j3 = swapjob!(p, j3; N=300, description = "[3]: N bounded", columns = cols)
            end
            if i == 250
                j1 = swapjob!(p, j1, description = "[1]: Lost bound!", N=nothing, inherit = true)
            end

            update!.([j1, j2, j3])
            sleep(0.02)
        end
    end
end
```